### PR TITLE
Updated Changelogs for dotnet core SDK (1.4.0) & desktop SDK (1.2.2)

### DIFF
--- a/release-notes/core/CHANGELOG.md
+++ b/release-notes/core/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.0 (2026-02-26)
+### Trimble.ID
+
+- Enhancements:
+ 
+    - Added account_id and data_region fields in the userinfo response.
+ 
 ## 1.3.2 (2025-07-21)
 * Trimble.ID
 	- Default leeway time has been added to renew the token 5 mins before expiration  to prevent disruptions and address edge cases where a token might expire during a critical operation. This is addressed for Client Credential Grant type provider

--- a/release-notes/desktop/CHANGELOG.md
+++ b/release-notes/desktop/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.2.2 (2026-02-26)
+### Trimble.ID.Desktop
+  
+- Enhancements: 
+
+    - Added account_id and data_region fields in the userinfo response.
+    - Updated browser launch mechanism to prevent PATH conflicts caused by external executables named start, ensuring reliable login flow across environments. 
+
+- Dependency Update:
+
+    - Updated trimble-id to 1.4.0
+
 ## 1.2.1 (2025-06-17)
 * Trimble.ID.Desktop
 	- Removed unsigned assembly jose-jwt in favor of Microsoft.IdentityModel.JsonWebTokens for token validation.

--- a/release-notes/maui/CHANGELOG.md
+++ b/release-notes/maui/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.1.0 (2026-03-02)
+
+Enhancements:
+  - Added account_id and data_region fields in the userinfo response.
+  
+Dependency Update:
+  - Updated trimble-id to 1.4.0
+  
 # 2.0.1 (2025-06-10)
 
 - Bug Fix: The dynamic redirection port was not being used when the authenticator was reinitialized on the Windows platform.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to release-note documentation and do not affect runtime code paths.
> 
> **Overview**
> Adds new release entries to the Core (`1.4.0`), Desktop (`1.2.2`), and MAUI (`2.1.0`) changelogs.
> 
> The notes highlight new `userinfo` fields (`account_id`, `data_region`), Desktop’s browser launch reliability fix, and dependency bumps to `trimble-id` `1.4.0` for Desktop/MAUI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4aabd385f853549e9a34476c4bf72ade2b174bdf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->