### PR TITLE
security  and maintainers markdowns added

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 *                       @trimble-oss/platform-sdk-maintainers
 
 # Core SDK
-/docs/core/             @vineshparamasivam
+/docs/core/             @trimble-oss/platform-sdk-maintainers
 /release-notes/core/    @trimble-oss/platform-sdk-maintainers
 
 # Desktop SDK

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# Each line is a file pattern followed by one or more owners.
+# Order matters — later rules take precedence.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+*                       @trimble-oss/platform-sdk-maintainers
+
+# Core SDK
+/docs/core/             @vineshparamasivam
+/release-notes/core/    @trimble-oss/platform-sdk-maintainers
+
+# Desktop SDK
+/docs/desktop/          @trimble-oss/platform-sdk-maintainers
+/release-notes/desktop/ @trimble-oss/platform-sdk-maintainers
+
+# MAUI SDK
+/docs/maui/             @trimble-oss/platform-sdk-maintainers
+/release-notes/maui/    @trimble-oss/platform-sdk-maintainers
+
+# Samples
+/samples/               @trimble-oss/platform-sdk-maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,27 @@
+# Maintainers
+
+This document lists the maintainers of the Trimble Identity SDK for .NET.
+
+## Active Maintainers
+
+<!-- Update this table with the current maintainers of the project. -->
+
+| Name | GitHub Handle | Role |
+| ---- | ------------- | ---- |
+| Vinesh Paramasivam | [vineshparamasivam](https://github.com/vineshparamasivam)  | Lead Maintainer |
+| Harshitha P | [harshitha-p-trimble](https://github.com/harshitha-p-trimble)  | Maintainer |
+| Karthik K | [karthikkandasamy21](https://github.com/karthikkandasamy21)  | Maintainer |
+
+## Responsibilities
+
+Maintainers are responsible for:
+
+- Reviewing and merging pull requests
+- Triaging issues and feature requests
+- Publishing new releases to [NuGet](https://www.nuget.org/packages?q=Trimble.ID)
+- Keeping documentation and samples up to date
+- Enforcing the project's [security policy](./SECURITY.md)
+
+## Becoming a Maintainer
+
+If you are interested in becoming a maintainer, please reach out to [support@trimble.com](mailto:support@trimble.com).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Report security vulnerabilities by emailing the Trimble Cybersecurity team at:
+
+    cybersecurity@trimble.com
+
+Report security vulnerabilities in third-party modules to the person or team maintaining the module.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it to a primary handler. This person will coordinate the fix and release process, involving the following steps:
+
+- Confirm the problem and determine the affected versions.
+- Audit code to find any potential similar problems.
+- Prepare fixes for all releases still under maintenance. These fixes will be released as fast as possible.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds repository governance/docs only, with no runtime or API changes. Risk is limited to PR review routing via `CODEOWNERS`.
> 
> **Overview**
> Introduces repository governance documentation by adding `MAINTAINERS.md` (project maintainer roster/responsibilities) and `SECURITY.md` (vulnerability reporting/disclosure guidance).
> 
> Adds `.github/CODEOWNERS` to route reviews to `@trimble-oss/platform-sdk-maintainers` by default and for key docs/release-notes/sample paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6810bd2b08a8d9370c5f7f26b2002c193e856b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->