### PR TITLE
⚠️ Warning: update public SECURITY.md reporting instructions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Report security vulnerabilities to the Trimble Cybersecurity team at:
 
-    https://www.trimble.com/en/our-commitment/responsible-business/data-privacy-and-security/report-cybersecurity-issues/form
+<https://www.trimble.com/en/our-commitment/responsible-business/data-privacy-and-security/report-cybersecurity-issues/form>
 
 Report security vulnerabilities in third-party modules to the person or team maintaining the module.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Reporting a Vulnerability
 
-Report security vulnerabilities by emailing the Trimble Cybersecurity team at:
+Report security vulnerabilities to the Trimble Cybersecurity team at:
 
-    cybersecurity@trimble.com
+    https://www.trimble.com/en/our-commitment/responsible-business/data-privacy-and-security/report-cybersecurity-issues/form
 
 Report security vulnerabilities in third-party modules to the person or team maintaining the module.
 


### PR DESCRIPTION
⚠️ **Warning:** this is a proactive compliance update ahead of [trimble-oss/oss-overseer#170](https://github.com/trimble-oss/oss-overseer/pull/170).

## Why this PR exists
A public policy update is queued in `oss-overseer` that will require public repositories to do both of the following in `SECURITY.md`:

1. Include the Trimble public security form URL:

       https://www.trimble.com/en/our-commitment/responsible-business/data-privacy-and-security/report-cybersecurity-issues/form

2. Stop using `cybersecurity@trimble.com`, which is for internal use only.

## What this PR changes
- updates the `Reporting a Vulnerability` section to point to the approved public form
- removes the internal-only email address
- leaves the rest of the file unchanged

## Why this matters
If [trimble-oss/oss-overseer#170](https://github.com/trimble-oss/oss-overseer/pull/170) merges before this repo updates `SECURITY.md`, the next public audit will report a new **MUST** violation for this repository.

This PR is meant as an early warning and a low-noise fix before that rollout happens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates the security vulnerability reporting instructions; no runtime code paths are affected.
> 
> **Overview**
> Updates `SECURITY.md` to direct vulnerability reports to the approved Trimble public security reporting form, removing the internal `cybersecurity@trimble.com` email reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5622060a9152c2102f4ea7fb360764e7464ac2ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->